### PR TITLE
fix: remove old site’s Service Worker

### DIFF
--- a/static/service-worker.js
+++ b/static/service-worker.js
@@ -1,0 +1,1 @@
+self.registration.unregister();


### PR DESCRIPTION
Naming matters, kids.