### PR TITLE
fix: remove preload to avoid errors

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -32,12 +32,6 @@ export default ({ children, title, className = '' }) => [
     <html lang="en" />
     <link rel="preconnect" href="https://use.typekit.net" />
     <link rel="preconnect" href="https://p.typekit.net" />
-    <link
-      rel="preload"
-      href="https://use.typekit.net/fnr1orp.css"
-      as="stylesheet"
-      crossOrigin
-    />
 
     <meta charSet="utf-8" />
     <meta name="viewport" content="initial-scale=1.0, width=device-width" />


### PR DESCRIPTION
I’m still not sure I’m doing this right, but the preload was giving me errors, and Lighthouse doesn’t seem to complain without it, so I’m making the assumption that a `preconnect` is enough in this case.