### PR TITLE
Update gatsby-mdx

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -133,10 +133,7 @@ exports.createPages = async ({ graphql, actions }) => {
 
     createPage({
       path: slug,
-      component: componentWithMDXScope(
-        path.resolve('src/templates/post.js'),
-        post.childMdx.code.scope,
-      ),
+      component: path.resolve('src/templates/post.js'),
       context: {
         imageRegex: `/${image}/`,
         offer: `/offers/${cta}/`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2024,13 +2024,6 @@ babel-plugin-external-helpers@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-gather-exports@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-gather-exports/-/babel-plugin-gather-exports-0.0.1.tgz#f71ea096872fabf7af966d652f1f544b13b92671"
-  integrity sha512-t4gbfvKBQd2PrE8uaxkXlUyz/n/1DvcXZ5KTCL7jzAyCWva7PpQllE3RjFYlYSsS/7FAw7diE1dTerCwgKLeMw==
-  dependencies:
-    json5 "^2.0.1"
-
 babel-plugin-istanbul@^4.0.0:
   version "4.1.6"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz#36c59b2192efce81c5b378321b74175add1c9a45"
@@ -2072,16 +2065,6 @@ babel-plugin-module-resolver@^2.7.1:
     find-babel-config "^1.0.1"
     glob "^7.1.1"
     resolve "^1.2.0"
-
-babel-plugin-pluck-exports@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-pluck-exports/-/babel-plugin-pluck-exports-0.0.1.tgz#97b500d679043de9445e947fb84433bf8c7aa525"
-  integrity sha512-oDLscaMIQlv/a8Vrpolmqbvc3yJCYrTo6uOG60962NiUhrWngxZCX9THGkt3w7JQqmi3TMGEkzNfMvIvxAA0Kg==
-
-babel-plugin-pluck-imports@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-pluck-imports/-/babel-plugin-pluck-imports-0.0.1.tgz#e5a68b33c66213c62499c0be620ab6583055d9c0"
-  integrity sha512-AkPrrNHUBOckkZgHdF6EY8VVkcwbOnS9IUPif9le3Xw0FquTYeyBLRiMo5P9luA3Iy/qzouMk8IoDSL8cozq8A==
 
 babel-plugin-remove-graphql-queries@^2.5.2:
   version "2.5.2"
@@ -6436,14 +6419,11 @@ gatsby-link@^2.0.7:
     prop-types "^15.6.1"
 
 gatsby-mdx@^0.3.1-ci.225:
-  version "0.3.1-ci.225"
-  resolved "https://registry.yarnpkg.com/gatsby-mdx/-/gatsby-mdx-0.3.1-ci.225.tgz#5c990f8baf955fd1c2c703fbb1b0aa177703f909"
-  integrity sha512-/rx1rfi6+Wq5CMYPC8HnspN42NW2r1XMz7cY4lAgtYouUgRtbUUFQ9BqTNdCzQbmt1JYwcI7EbBuBGEQfnjB+w==
+  version "0.3.1-ci.236"
+  resolved "https://registry.yarnpkg.com/gatsby-mdx/-/gatsby-mdx-0.3.1-ci.236.tgz#77f552616990f853577a94e4824341ee079aabec"
+  integrity sha512-qmTs0gt+3arc9/L0I/ITsJvWC30aOWeM/m3TYqDowUTWLrUS7Bg3Ud+c2bg7y3VABhgJFhvhsr2oekQBylpdww==
   dependencies:
     "@babel/plugin-proposal-object-rest-spread" "^7.0.0"
-    babel-plugin-gather-exports "^0.0.1"
-    babel-plugin-pluck-exports "^0.0.1"
-    babel-plugin-pluck-imports "^0.0.1"
     debug "^4.0.1"
     escape-string-regexp "^1.0.5"
     fs-extra "^7.0.0"
@@ -9138,7 +9118,7 @@ json5@^1.0.0, json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
-json5@^2.0.1, json5@^2.1.0:
+json5@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.0.tgz#e7a0c62c48285c628d20a10b85c89bb807c32850"
   integrity sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==


### PR DESCRIPTION
* New version handles compiling wrapRootElement and MDXRenderer using the
  user's loaders.js()
* removed componentWithMDXScope, which is no longer necessary