### PR TITLE
fix: remove Service Worker

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -223,12 +223,15 @@ module.exports = {
         ],
       },
     },
-    {
-      resolve: 'gatsby-plugin-offline',
-      options: {
-        globIgnores: ['**/*.pdf'],
-      }
-    },
+    // I give up.
+    'gatsby-plugin-remove-serviceworker',
+    // {
+    //   resolve: 'gatsby-plugin-offline',
+    //   options: {
+    //     globIgnores: ['**/*.pdf'],
+    //   }
+    // },
+
     {
       resolve: 'gatsby-source-airtable',
       options: {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "gatsby-plugin-manifest": "^2.0.6",
     "gatsby-plugin-offline": "^2.0.9",
     "gatsby-plugin-react-helmet": "^3.0.0",
+    "gatsby-plugin-remove-serviceworker": "^1.0.0",
     "gatsby-plugin-sharp": "^2.0.8",
     "gatsby-plugin-twitter": "^2.0.6",
     "gatsby-remark-copy-linked-files": "^2.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6784,6 +6784,11 @@ gatsby-plugin-react-helmet@^3.0.0:
   dependencies:
     "@babel/runtime" "^7.0.0"
 
+gatsby-plugin-remove-serviceworker@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-remove-serviceworker/-/gatsby-plugin-remove-serviceworker-1.0.0.tgz#9fb433bc8bd766e14e1d3711c4ac6f051e1dff7c"
+  integrity sha1-n7QzvIvXZuFOHTcRxKxvBR4d/3w=
+
 gatsby-plugin-sharp@^2.0.8:
   version "2.0.19"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-sharp/-/gatsby-plugin-sharp-2.0.19.tgz#8a0e6452989e901375aefe819cf2a85b951ddf28"


### PR DESCRIPTION
There are enough problems with this (broken PDF downloads in Chrome, occasional blank pages, etc.) that it doesn’t feel worth it right now.